### PR TITLE
Update normalize.css to v3.0.2.

### DIFF
--- a/build/themes/rainier/scss/_basics.scss
+++ b/build/themes/rainier/scss/_basics.scss
@@ -1,0 +1,510 @@
+@import 'normalize';
+@import 'grid';
+@import 'component';
+
+$fg: black !default;
+$bg: white !default;
+$link: blue !default;
+
+$dark-gray: gray !default;
+$gray: lightgray !default;
+$light-gray: whitesmoke !default;
+
+$font-size: 14px !default;
+$sans-serif: Helvetica, Arial, sans-serif !default;
+$monospace: "Menlo", monospace !default;
+
+$ratio: 1.618 !default;
+$indent: em($ratio) !default;
+
+body {
+  margin: 0;
+  line-height: $ratio;
+  background-color: $bg;
+  color: $fg;
+  font-size: $font-size;
+  font-family: $sans-serif;
+}
+
+a {
+  color: $link;
+
+  &:hover {
+    color: $link-hover;
+    text-decoration: none;
+  }
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin: $indent 0;
+  text-rendering: optimizeLegibility;
+}
+
+p {
+  margin: $indent 0;
+}
+
+ul,
+ol {
+  margin: $indent 0;
+
+  ul,
+  ol {
+    margin: 0;
+  }
+}
+
+dl {
+  margin: $indent 0;
+
+  dl {
+    margin: 0;
+  }
+}
+
+pre {
+  overflow: auto;
+  margin: $indent 0;
+  padding: $indent;
+  background-color: $light-gray;
+  color: $fg;
+  font-family: $monospace;
+}
+
+blockquote {
+  margin: 0 0 0 $indent;
+  padding: 0 $indent;
+  border-left: 3px solid $gray;
+}
+
+table {
+  width: 100%;
+  margin: $indent 0;
+  border-spacing: 0;
+  border: 1px solid $gray;
+  border-width: 1px 0 0 1px;
+
+  th,
+  td {
+    padding: 0.5em;
+    border: solid $gray;
+    border-width: 0 1px 1px 0;
+    text-align: left;
+    vertical-align: top;
+    word-wrap: break-word;
+  }
+
+  th {
+    background-color: $light-gray;
+    color: $fg;
+  }
+}
+
+hr {
+    margin: ($indent * 2) 0;
+}
+
+input,
+select,
+textarea,
+button,
+.button {
+    display: inline-block;
+    margin: 0;
+    font-size: 100%;
+    vertical-align: middle;
+    @extend %border-box;
+}
+input {
+  padding: 0 0.25em;
+
+  &[type=checkbox],
+  &[type=radio] {
+    padding: 0;
+  }
+}
+textarea {
+    padding: 0.2em 0.25em;
+    overflow: auto;
+    vertical-align: top;
+    resize: vertical;
+}
+
+.pagination {
+  margin: ($indent * 2) 0;
+  text-align: center;
+
+  @media (min-width: 700px) {
+    margin: $indent 0;
+  }
+
+  ul {
+    display: block;
+    padding: 0;
+  }
+
+  li {
+    display: inline-block;
+
+    a {
+      padding: 0 10px;
+      text-decoration: none;
+
+      &[rel="prev"]:before {
+        content: '\00AB';
+        margin-right: 0.3em;
+      }
+
+      &[rel="next"]:after {
+        content: '\00BB';
+        margin-left: 0.3em;
+      }
+    }
+  }
+}
+
+// Navigation
+[role="navigation"] {
+  margin-top: $indent;
+
+  ul {
+    margin: 10px 0 0;
+
+    li {
+      display: inline-block;
+    }
+  }
+}
+
+// Header
+[role="banner"] {
+
+  &#header {
+    background-size: contain;
+  }
+
+  #header-inner {
+    position: relative;
+    padding: 35px 0 0;
+  }
+
+  #header-content {
+    width: auto;
+    min-height: 150px;
+    margin: $indent 1em;
+
+    @media (min-width: 930px) {
+      margin: $indent $gap;
+    }
+  }
+
+  h1 {
+    margin-top: 0;
+    margin-bottom: 0;
+
+    img {
+      max-width: 200px;
+      height: auto;
+    }
+  }
+
+  .description {
+    margin-top: 0;
+  }
+
+  [role="navigation"] {
+    position: absolute;
+    top: 0;
+    height: 35px;
+    line-height: 35px;
+    margin: 0;
+    @extend %clearfix;
+
+    @media (min-width: 930px) {
+      width: 100%;
+      padding: 0;
+
+      ul {
+        margin: 0 $gap;
+
+        li {
+          float: left;
+          padding: 0;
+        }
+      }
+
+      a {
+        display: block;
+        padding: 0 1em 0 0;
+        text-decoration: none;
+      }
+    }
+  }
+}
+
+// Breadcrumbs
+.breadcrumb {
+  margin: 0 0 $indent;
+  padding: 0;
+  font-size: 90%;
+
+  @media (min-width: 930px) {
+    padding-right: 15px;
+    padding-left: 15px;
+  }
+
+  li {
+    list-style-type: none;
+
+    &:after {
+      content: '\2192';
+      margin: 0 0.5em;
+    }
+
+    &:last-child:after {
+      display: none;
+    }
+
+    @media (min-width: 700px) {
+      display: inline-block;
+    }
+  }
+}
+
+// Entry
+.entry,
+.page,
+section {
+  margin-bottom: ($indent * 3);
+
+  h2 {
+    margin: 0 0 0.3em;
+
+    + footer ul {
+      margin-top: $harf-indent;
+      padding: 0;
+
+      li {
+        display: inline;
+      }
+    }
+  }
+
+  img {
+    max-width: 100%;
+    height: auto;
+  }
+}
+
+
+// Widget
+.widget {
+
+  ul,
+  ol {
+    margin: $harf-indent 0;
+    padding: 0;
+
+    ul,
+    ol {
+      margin: 0;
+    }
+  }
+
+  li {
+    list-style-type: none;
+    margin-bottom: 5px;
+  }
+
+  img {
+    max-width: 100%;
+    height: auto;
+  }
+
+  @media (min-width: 930px) {
+    margin-right: 15px;
+  }
+}
+
+
+// Entries List
+#posts {
+  margin-bottom: $indent;
+
+  h2 {
+    margin: 0;
+    padding-bottom: 0.2em;
+    border-bottom: 1px solid $gray;
+  }
+
+  ol {
+    margin-top: 0;
+    padding-left: 0;
+  }
+
+  li {
+    list-style-type: none;
+    padding: $harf-indent 0;
+    border-top: 0;
+    border-bottom: 1px solid $light-gray;
+    @extend %clearfix;
+
+    time,
+    a {
+      display: block;
+      padding: 0 $gap;
+    }
+
+    a {
+      text-decoration: none;
+    }
+
+    @media (min-width: 700px) {
+      time,
+      a {
+        float: left;
+      }
+
+      time {
+        width: $colspan03;
+      }
+
+      a {
+        width: $colspan09;
+      }
+    }
+  }
+
+  nav {
+    margin-top: -$harf-indent;
+    text-align: right;
+
+    a:after {
+      content: '\00a0\00BB';
+    }
+  }
+}
+
+
+// Footer
+[role="contentinfo"] {
+  margin-top: ($indent * 2);
+  padding: 10px 0;
+
+  [role="navigation"],
+  .license,
+  .poweredby {
+    margin: $harf-indent 1em;
+  }
+
+  [role="navigation"] {
+
+    ul {
+      margin-top: 0;
+    }
+
+    li {
+      display: list-item;
+      list-style-type: none;
+    }
+  }
+
+  .poweredby {
+    clear: both;
+    text-align: right;
+  }
+
+  @media (min-width: 930px) {
+    [role="navigation"],
+    .license,
+    .poweredby {
+      margin: $harf-indent 0;
+      padding-right: $gap;
+      padding-left: $gap;
+    }
+
+    [role="navigation"],
+    .license {
+      float: left;
+    }
+
+    [role="navigation"] {
+      width: $colspan08;
+
+      li {
+        display: inline-block;;
+      }
+    }
+
+    .license {
+      width: $colspan04;
+      text-align: right;
+    }
+  }
+}
+
+// Search
+#search {
+  margin-bottom: $indent;
+  text-align: center;
+
+  div {
+    display: inline-block;
+    position: relative;
+
+    @media (min-width: 930px) {
+      display: block;
+    }
+  }
+
+  input[type="text"] {
+    width: ($indent * 10);
+    height: ($indent * 1.5);
+    padding: 0 ($indent * 1.5) 0 0.5em;
+    border: 1px solid $gray;
+    line-height: 1.3;
+    box-shadow: inset 0 1px 1px 0 rgba(0, 0, 0, 0.2);
+
+    @media (min-width: 930px) {
+      width: 100%;
+    }
+  }
+
+  button {
+    position: absolute;
+    top: 0;
+    right: 0;
+    display: table-cell;
+    width: ($indent * 1.5);
+    height: ($indent * 1.5);
+    padding: 0;
+    border: 0;
+    background: transparent;
+    opacity: 0.8;
+
+    &:hover {
+      opacity: 1;
+    }
+
+    img {
+    vertical-align: middle;
+    }
+  }
+}
+
+// Tag Cloud
+.widget.widget-tag-cloud ul {
+  padding: 0;
+
+  li {
+    display: inline;
+    margin: 0 5px 0 0;
+    padding: 0;
+    @include tag-cloud();
+  }
+}

--- a/build/themes/rainier/scss/_clearfix.scss
+++ b/build/themes/rainier/scss/_clearfix.scss
@@ -1,0 +1,13 @@
+@mixin clearfix {
+    zoom: 1;
+    &:before,
+    &:after {
+        display: block;
+        height: 0;
+        visibility: hidden;
+        content: "\0020";
+    }
+    &:after {
+        clear: both;
+    }
+}

--- a/build/themes/rainier/scss/_component.scss
+++ b/build/themes/rainier/scss/_component.scss
@@ -1,0 +1,66 @@
+@import "clearfix";
+
+@mixin border-radius($params) {
+  @each $vendor in null {
+    #{$vendor}border-radius: $params;
+  }
+}
+
+@mixin box-shadow($params, $inset_params:null) {
+  @each $vendor in null {
+    #{$vendor}box-shadow: $params, $inset_params;
+  }
+}
+
+@mixin box-sizing($model:border-box) {
+  @each $vendor in -moz-, null {
+    #{$vendor}box-sizing: $model;
+  }
+}
+
+@mixin opacity($degree) {
+  $degree_num: ($degree * 100);
+  opacity: $degree;
+  -ms-filter: 'alpha(opacity = #{$degree_num})';
+  filter: alpha(opacity = $degree_num);
+}
+
+@mixin linear-gradient($start, $last) {
+  @each $vendor in -ms-, -moz-, -webkit-, null {
+    background-image: #{$vendor}linear-gradient($start, $last);
+  }
+}
+
+@mixin tag-cloud($base: 1em) {
+  font-size: $base;
+  line-height: 1.2 * $base;
+  &.rank-1 {
+    font-size: ($base * 1.8);
+  }
+  &.rank-2 {
+    font-size: ($base * 1.5);
+  }
+  &.rank-3 {
+    font-size: ($base * 1.3);
+  }
+  &.rank-4 {
+    font-size: $base;
+  }
+  &.rank-5 {
+    font-size: ($base * 0.9);
+  }
+  &.rank-6 {
+    font-size: ($base * 0.85);
+  }
+  &.rank-7 {
+    font-size: ($base * 0.7);
+  }
+}
+
+%border-box {
+  @include box-sizing(border-box);
+}
+
+%clearfix {
+  @include clearfix;
+}

--- a/build/themes/rainier/scss/_debug.scss
+++ b/build/themes/rainier/scss/_debug.scss
@@ -1,0 +1,41 @@
+body {
+    outline: 1px solid #eee;
+
+    > * {
+        outline: 1px solid #ccc;
+        background-color: #eee;
+
+        > * {
+            outline: 1px solid #85d9e9;
+            background-color: #e7f8fb;
+
+            > * {
+                outline: 1px solid #8cea86;
+                background-color: #e8fbe7;
+
+                > * {
+                    outline: 1px solid #ffd292;
+                    background-color: #fff7d8;
+
+                    > * {
+                        outline: 1px solid #e656b1;
+                        background-color: #f9d3eb;
+
+                        > * {
+                            outline: 1px solid #c9171e;
+                            background-color: #d3381c;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+a,
+input,
+textarea,
+select {
+    outline: 0;
+    background: none;
+}

--- a/build/themes/rainier/scss/_decoration.scss
+++ b/build/themes/rainier/scss/_decoration.scss
@@ -1,0 +1,278 @@
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  a {
+    color: $fg;
+    text-decoration: none;
+
+    &:hover {
+      color: $link-hover;
+    }
+  }
+}
+
+.entry,
+.page {
+
+  .entry-title {
+    font-size: em($ratio);
+
+    + footer {
+      margin-top: -1em;
+    }
+  }
+
+  footer {
+    color: $dark-gray;
+  }
+}
+
+#container {
+  #header-inner,
+  #content-inner,
+  #footer-inner {
+    width: auto;
+  }
+}
+
+.entry-content {
+  nav {
+    margin-bottom: $indent;
+  }
+}
+
+// Header
+#header[role="banner"] {
+  position: relative;
+  background-color: $bg;
+  border: solid $gray;
+  border-width: 0 1px 1px;
+
+  @media (max-width: 930px) {
+    border-width: 0 0 1px;
+  }
+
+  #header-inner {
+    padding: 0;
+  }
+
+  #header-content {
+    min-height: 200px;
+    margin: 0;
+    padding: 1px 0;
+    background-color: $fg;
+    background-image: url("../img/linen-texture.png");
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: 100%;
+    color: rgb(255, 255, 255);
+
+    a {
+      color: rgb(255, 255, 255);
+      text-decoration: none;
+    }
+
+    &:before {
+      position: absolute;
+      bottom: 45px;
+      content: "\00a0";
+      display: block;
+      width: 100%;
+      height: 200px;
+      background: transparent url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAADICAYAAAAp8ov1AAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyRpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMy1jMDExIDY2LjE0NTY2MSwgMjAxMi8wMi8wNi0xNDo1NjoyNyAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNiAoTWFjaW50b3NoKSIgeG1wTU06SW5zdGFuY2VJRD0ieG1wLmlpZDo1Qjk5NDNGMzE1MEYxMUUyOTZFQ0I0QTFBM0I0MTlDQiIgeG1wTU06RG9jdW1lbnRJRD0ieG1wLmRpZDo1Qjk5NDNGNDE1MEYxMUUyOTZFQ0I0QTFBM0I0MTlDQiI+IDx4bXBNTTpEZXJpdmVkRnJvbSBzdFJlZjppbnN0YW5jZUlEPSJ4bXAuaWlkOjVCOTk0M0YxMTUwRjExRTI5NkVDQjRBMUEzQjQxOUNCIiBzdFJlZjpkb2N1bWVudElEPSJ4bXAuZGlkOjVCOTk0M0YyMTUwRjExRTI5NkVDQjRBMUEzQjQxOUNCIi8+IDwvcmRmOkRlc2NyaXB0aW9uPiA8L3JkZjpSREY+IDwveDp4bXBtZXRhPiA8P3hwYWNrZXQgZW5kPSJyIj8+aXQCyAAAAP1JREFUeNpkU9sRwzAIU7z/ar1uJGrekOYjZwxIAgNEBAf3O9/v5zlmCvAchKPu1KSaerp3GgJzrDRKhqjjmjgsPEvLXxFRTWyvme6wEPiJzqug4kSZoUTQE0EzAwWOR801AE4tiXdPzLhJno4XirEJVohneIdSATvN9KGDTTMrRBYbuOKE/2n+HhIVuSrpyi2j7qSI6o7VXcNrZCmRLFPY+ghnQ6O8iTBrQwvqjpfwbnb3aopczYmeEuPJ/NTFBEDMH6slwAKI4Cprj8V05FzF0y4FiTLnRSrDG2G7wBxWvAfdgl14LERkIKcOY1NCONBKEfv7t1a1pvf7CTAA0PbnN/2iLhwAAAAASUVORK5CYII=) left bottom repeat-x;
+      @include linear-gradient(rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.6));
+    }
+  }
+
+  h1 {
+    position: relative;
+    margin: $indent 10px 0;
+    font-size: $indent;
+    text-align: center;
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.8);
+
+    img {
+      max-width: 200px;
+      height: auto;
+    }
+  }
+
+  #header-description {
+    position: relative;
+    margin: 0 10px;
+    text-align: center;
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.5);
+  }
+
+  [role="navigation"] {
+    position: static;
+    height: 45px;
+    line-height: 45px;
+
+    @media (min-width: 930px) {
+      width: auto;
+    }
+
+    ul {
+      margin: 0;
+
+      li {
+        border-right: 1px solid $gray;
+      }
+    }
+
+    a {
+      height: 45px;
+      padding: 0 $harf-indent;
+      line-height: 45px;
+      color: $fg;
+
+      &:hover {
+        color: $link-hover;
+      }
+    }
+  }
+}
+
+// Entries List
+#posts {
+  time {
+    color: $dark;
+  }
+}
+
+// Widget
+.widget {
+  margin-bottom: ($indent * 2);
+
+  h3 {
+    margin-bottom: 0;
+    border-bottom: 1px solid $gray;
+  }
+
+  .widget-content {
+    margin: $harf-indent 0;
+    font-size: 90%;
+  }
+
+  ul,
+  ol {
+    margin: $harf-indent 0;
+    padding-left: $indent;
+
+    ul,
+    ol {
+      margin: 0;
+    }
+  }
+
+  li {
+    list-style-type: disc;
+  }
+}
+
+// Archive Dropdown, Tag Cloud
+.widget-tag-cloud,
+.widget-archive-dropdown {
+  .widget-content {
+    margin: $harf-indent;
+  }
+}
+
+// Footer
+footer {
+  color: $gray;
+  font-size: 90%;
+
+  p {
+    margin: 0;
+  }
+}
+
+[role="contentinfo"] {
+  border-top: 1px solid $gray;
+  color: $gray;
+
+  a {
+    color: $gray;
+  }
+  [role="navigation"] {
+
+    a {
+      color: $gray;
+    }
+  }
+}
+
+// Pagination
+#index-main,
+#individual-main,
+#search-results-main {
+  .pagination {
+    border-top: 1px solid $gray;
+  }
+}
+
+// Feedback
+.feedback {
+  border-top: 1px solid $gray;
+}
+
+.comment {
+  border-bottom: 1px dotted $light-gray;
+
+  header {
+
+    a {
+      color: $gray;
+      text-decoration: none;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+
+    h3 {
+      a {
+        color: $fg;
+        text-decoration: none;
+
+        &:hover {
+          color: $link-hover;
+        }
+      }
+    }
+  }
+}
+
+// Form
+.text,
+.button {
+  height: 1.75em;
+  line-height: normal;
+
+  &::-moz-focus-inner {
+    border: 0;
+    padding: 0;
+  }
+}
+
+.text {
+  width: 75%;
+  outline: 0;
+  border: 1px solid $gray;
+  line-height: 1.3;
+  background-color: white;
+  color: black;
+}
+
+// Search Results
+#search-results-main {
+  .title {
+    border-bottom: 1px solid $gray;
+    margin: 0 0 $indent;
+  }
+}

--- a/build/themes/rainier/scss/_feedback.scss
+++ b/build/themes/rainier/scss/_feedback.scss
@@ -1,0 +1,161 @@
+@import 'function';
+
+@import 'variable';
+@import 'component';
+
+.feedback {
+  margin-top: $indent;
+
+  @media (min-width: 700px) {
+    margin-top: $indent;
+  }
+
+  h2 {
+    margin: 1em 0 $indent;
+  }
+}
+
+.comment {
+  margin-bottom: $harf-indent;
+  border-bottom: 1px solid;
+
+  header {
+    @extend %clearfix;
+
+    h3 {
+      display: inline;
+      margin: 0;
+      font-size: 110%;
+    }
+  }
+  time {
+    margin-left: $harf-indent;
+    font-size: 90%;
+  }
+
+  p {
+    margin: $harf-indent 0;
+  }
+
+  .reply {
+    text-align: right;
+  }
+}
+
+.message {
+  padding: $harf-indent;
+  background-color: $light-gray;
+  color: $fg;
+}
+
+#comment-greeting {
+  margin-top: ($indent * 2);
+
+  + #comments-form {
+    margin-top: $indent;
+  }
+}
+
+#comments-form {
+  margin-top: ($indent * 2);
+
+  fieldset {
+    margin: 0;
+    padding: 0;
+    border: 0;
+
+    legend {
+      display: none;
+    }
+  }
+}
+
+#comments-open-text {
+  textarea {
+    width: 100%;
+    height: ($indent * 8);
+  }
+}
+
+#comments-open-data {
+  ul {
+    margin: $indent 0;
+    padding: 0;
+  }
+
+  li {
+    list-style-type: none;
+    margin-bottom: $harf-indent;
+
+    label {
+      display: block;
+      text-align: left;
+    }
+
+    input[type="text"] {
+      width: 100%;
+
+      @media (min-width: 700px) {
+        width: 75%;
+      }
+    }
+  }
+}
+
+#comments-open-footer {
+  margin-top: $indent;
+  text-align: center;
+
+  @media (min-width: 930px) {
+    text-align: left;
+  }
+
+  input[type="submit"],
+  input[type="button"] {
+    width: 100%;
+    margin-bottom: $harf-indent;
+
+    @media (min-width: 700px) {
+      width: auto;
+      margin-right: $harf-indent;
+    }
+  }
+}
+
+#comments-open-captcha {
+  margin: $indent 0;
+
+  .label {
+    display: none;
+  }
+
+  #captcha_code {
+    width: 150px;
+    margin: $harf-indent 0;
+    @extend %border-box;
+  }
+
+  #comments-open-captcha p {
+    margin: 0;
+    font-size: 90%;
+  }
+}
+
+#trackback-url {
+  margin-bottom: ($indent * 2);
+}
+
+.trackback {
+  margin-bottom: $indent;
+  padding-bottom: $indent;
+  border-bottom: 1px dotted $gray;
+
+  time {
+    color: $gray;
+    font-size: 90%;
+  }
+
+  p {
+    margin: $harf-indent 0 0;
+  }
+}

--- a/build/themes/rainier/scss/_function.scss
+++ b/build/themes/rainier/scss/_function.scss
@@ -1,0 +1,6 @@
+// number to em
+@function em($num) {
+  $num: ($num * 1em);
+
+  @return $num;
+}

--- a/build/themes/rainier/scss/_grid.scss
+++ b/build/themes/rainier/scss/_grid.scss
@@ -1,0 +1,28 @@
+$columns: 12;
+$column: (100% / $columns);
+$gutter: 4%;
+$gap: ($gutter / 2);
+
+$colspan: ();
+
+@for $i from 1 through $columns {
+  $column_width: ($column * $i - $gutter);
+  $colspan: append($colspan, $column_width);
+}
+
+$colspan01: nth($colspan, 1);
+$colspan02: nth($colspan, 2);
+$colspan03: nth($colspan, 3);
+$colspan04: nth($colspan, 4);
+$colspan05: nth($colspan, 5);
+$colspan06: nth($colspan, 6);
+$colspan07: nth($colspan, 7);
+$colspan08: nth($colspan, 8);
+$colspan09: nth($colspan, 9);
+$colspan10: nth($colspan, 10);
+$colspan11: nth($colspan, 11);
+$colspan12: nth($colspan, 12);
+// $colspan13: nth($colspan, 13);
+// $colspan14: nth($colspan, 14);
+// $colspan15: nth($colspan, 15);
+// $colspan16: nth($colspan, 16);

--- a/build/themes/rainier/scss/_layout.scss
+++ b/build/themes/rainier/scss/_layout.scss
@@ -1,0 +1,129 @@
+// Grid
+.span {
+  width: 100%;
+  margin: 0;
+}
+
+@media (min-width: 700px) {
+  .span {
+      float: left;
+  }
+  .span1 { width: $colspan01 }
+  .span2 { width: $colspan02 }
+  .span3 { width: $colspan03 }
+  .span4 { width: $colspan04 }
+  .span5 { width: $colspan05 }
+  .span6 { width: $colspan06 }
+  .span7 { width: $colspan07 }
+  .span8 { width: $colspan08 }
+  .span9 { width: $colspan09 }
+  .span10 { width: $colspan10 }
+  .span11 { width: $colspan11 }
+  .span12 { width: $colspan12 }
+//   .span13 { width: $colspan13 }
+//   .span14 { width: $colspan14 }
+//   .span15 { width: $colspan15 }
+//   .span16 { width: $colspan16 }
+}
+
+#container {
+  #container-inner,
+  #header-inner,
+  #content-inner,
+  #footer-inner {
+    width: auto;
+
+    @media (min-width: 930px) {
+      width: 940px;
+      margin-right: auto;
+      margin-left: auto;
+    }
+  }
+}
+
+// Header
+[role="banner"] {
+  margin: 0;
+
+  @media (min-width: 930px) {
+    margin: 0 auto;
+
+    h1 {
+      margin: 0;
+    }
+  }
+
+  [role="navigation"] {
+    padding: 0 1em;
+
+    ul {
+      display: none;
+      @extend %clearfix;
+    }
+
+    @media (min-width: 930px) {
+      ul {
+        display: block;
+      }
+
+      select {
+        display: none;
+      }
+    }
+  }
+}
+
+
+[role="navigation"] {
+  ul {
+    padding-left: 0;
+
+    li {
+      padding-right: 1.618em;
+    }
+  }
+}
+
+
+// Content
+#content {
+  margin: $indent 1em 0;
+  @extend %clearfix;
+
+  .related {
+    margin-top: ($indent * 3);
+  }
+
+  @media (min-width: 930px) {
+    margin-right: auto;
+    margin-left: auto;
+
+    [role="main"],
+    .related {
+      float: left;
+      min-height: 1px;
+    }
+    [role="main"] {
+      width: 640px;
+      padding-left: 15px;
+    }
+    .related {
+      width: 235px;
+      padding-left: 50px;
+      margin-top: 0;
+    }
+  }
+}
+
+
+// Footer
+[role="contentinfo"] {
+  margin: 0;
+  @extend %clearfix;
+
+  @media (min-width: 930px) {
+    margin: 0 auto;
+  }
+}
+
+

--- a/build/themes/rainier/scss/_normalize.scss
+++ b/build/themes/rainier/scss/_normalize.scss
@@ -1,0 +1,507 @@
+/*! normalize.css 2012-03-11T12:53 UTC - http://github.com/necolas/normalize.css */
+
+/* =============================================================================
+   HTML5 display definitions
+   ========================================================================== */
+
+/*
+ * Corrects block display not defined in IE6/7/8/9 & FF3
+ */
+
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+nav,
+section,
+summary {
+    display: block;
+}
+
+/*
+ * Corrects inline-block display not defined in IE6/7/8/9 & FF3
+ */
+
+audio,
+canvas,
+video {
+    display: inline-block;
+    *display: inline;
+    *zoom: 1;
+}
+
+/*
+ * Prevents modern browsers from displaying 'audio' without controls
+ * Remove excess height in iOS5 devices
+ */
+
+audio:not([controls]) {
+    display: none;
+    height: 0;
+}
+
+/*
+ * Addresses styling for 'hidden' attribute not present in IE7/8/9, FF3, S4
+ * Known issue: no IE6 support
+ */
+
+[hidden] {
+    display: none;
+}
+
+
+/* =============================================================================
+   Base
+   ========================================================================== */
+
+/*
+ * 1. Corrects text resizing oddly in IE6/7 when body font-size is set using em units
+ *    http://clagnut.com/blog/348/#c790
+ * 2. Prevents iOS text size adjust after orientation change, without disabling user zoom
+ *    www.456bereastreet.com/archive/201012/controlling_text_size_in_safari_for_ios_without_disabling_user_zoom/
+ */
+
+html {
+    font-size: 100%; /* 1 */
+    -webkit-text-size-adjust: 100%; /* 2 */
+    -ms-text-size-adjust: 100%; /* 2 */
+}
+
+/*
+ * Addresses font-family inconsistency between 'textarea' and other form elements.
+ */
+
+html,
+button,
+input,
+select,
+textarea {
+    font-family: sans-serif;
+}
+
+/*
+ * Addresses margins handled incorrectly in IE6/7
+ */
+
+body {
+    margin: 10px;
+    font-family: serif;
+    font-size: 16px;
+    background-color: #ccc;
+}
+
+
+/* =============================================================================
+   Links
+   ========================================================================== */
+
+/*
+ * Addresses outline displayed oddly in Chrome
+ */
+
+a:focus {
+    outline: thin dotted;
+}
+
+/*
+ * Improves readability when focused and also mouse hovered in all browsers
+ * people.opera.com/patrickl/experiments/keyboard/test
+ */
+
+a:hover,
+a:active {
+    outline: 0;
+}
+
+
+/* =============================================================================
+   Typography
+   ========================================================================== */
+
+/*
+ * Addresses font sizes and margins set differently in IE6/7
+ * Addresses font sizes within 'section' and 'article' in FF4+, Chrome, S5
+ */
+
+h1 {
+    font-size: 2em;
+    margin: 0.67em 0;
+}
+
+h2 {
+    font-size: 1.5em;
+    margin: 0.83em 0;
+}
+
+h3 {
+    font-size: 1.17em;
+    margin: 1em 0;
+}
+
+h4 {
+    font-size: 1em;
+    margin: 1.33em 0;
+}
+
+h5 {
+    font-size: 0.83em;
+    margin: 1.67em 0;
+}
+
+h6 {
+    font-size: 0.75em;
+    margin: 2.33em 0;
+}
+
+/*
+ * Addresses styling not present in IE7/8/9, S5, Chrome
+ */
+
+abbr[title] {
+    border-bottom: 1px dotted;
+}
+
+/*
+ * Addresses style set to 'bolder' in FF3+, S4/5, Chrome
+*/
+
+b,
+strong {
+    font-weight: bold;
+}
+
+blockquote {
+    margin: 1em 40px;
+}
+
+/*
+ * Addresses styling not present in S5, Chrome
+ */
+
+dfn {
+    font-style: italic;
+}
+
+/*
+ * Addresses styling not present in IE6/7/8/9
+ */
+
+mark {
+    background: #ff0;
+    color: #000;
+}
+
+/*
+ * Addresses margins set differently in IE6/7
+ */
+
+p,
+pre {
+    margin: 1em 0;
+}
+
+/*
+ * Corrects font family set oddly in IE6, S4/5, Chrome
+ * en.wikipedia.org/wiki/User:Davidgothberg/Test59
+ */
+
+pre,
+code,
+kbd,
+samp {
+    font-family: monospace, serif;
+    _font-family: 'courier new', monospace;
+    font-size: 1em;
+}
+
+/*
+ * Improves readability of pre-formatted text in all browsers
+ */
+
+pre {
+    white-space: pre;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+}
+
+/*
+ * 1. Addresses CSS quotes not supported in IE6/7
+ * 2. Addresses quote property not supported in S4
+ */
+
+/* 1 */
+
+q {
+    quotes: none;
+}
+
+/* 2 */
+
+q:before,
+q:after {
+    content: '';
+    content: none;
+}
+
+small {
+    font-size: 75%;
+}
+
+/*
+ * Prevents sub and sup affecting line-height in all browsers
+ * gist.github.com/413930
+ */
+
+sub,
+sup {
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+}
+
+sup {
+    top: -0.5em;
+}
+
+sub {
+    bottom: -0.25em;
+}
+
+
+/* =============================================================================
+   Lists
+   ========================================================================== */
+
+/*
+ * Addresses margins set differently in IE6/7
+ */
+
+dl,
+menu,
+ol,
+ul {
+    margin: 1em 0;
+}
+
+dd {
+    margin: 0 0 0 40px;
+}
+
+/*
+ * Addresses paddings set differently in IE6/7
+ */
+
+menu,
+ol,
+ul {
+    padding: 0 0 0 40px;
+}
+
+/*
+ * Corrects list images handled incorrectly in IE7
+ */
+
+nav ul,
+nav ol {
+    list-style: none;
+    list-style-image: none;
+}
+
+
+/* =============================================================================
+   Embedded content
+   ========================================================================== */
+
+/*
+ * 1. Removes border when inside 'a' element in IE6/7/8/9, FF3
+ * 2. Improves image quality when scaled in IE7
+ *    code.flickr.com/blog/2008/11/12/on-ui-quality-the-little-things-client-side-image-resizing/
+ */
+
+img {
+    border: 0; /* 1 */
+    -ms-interpolation-mode: bicubic; /* 2 */
+}
+
+/*
+ * Corrects overflow displayed oddly in IE9
+ */
+
+svg:not(:root) {
+    overflow: hidden;
+}
+
+
+/* =============================================================================
+   Figures
+   ========================================================================== */
+
+/*
+ * Addresses margin not present in IE6/7/8/9, S5, O11
+ */
+
+figure {
+    margin: 0;
+}
+
+
+/* =============================================================================
+   Forms
+   ========================================================================== */
+
+/*
+ * Corrects margin displayed oddly in IE6/7
+ */
+
+form {
+    margin: 0;
+}
+
+/*
+ * Define consistent border, margin, and padding
+ */
+
+fieldset {
+    border: 1px solid #c0c0c0;
+    margin: 0 2px;
+    padding: 0.35em 0.625em 0.75em;
+}
+
+/*
+ * 1. Corrects color not being inherited in IE6/7/8/9
+ * 2. Corrects text not wrapping in FF3
+ * 3. Corrects alignment displayed oddly in IE6/7
+ */
+
+legend {
+    border: 0; /* 1 */
+    padding: 0;
+    white-space: normal; /* 2 */
+    *margin-left: -7px; /* 3 */
+}
+
+/*
+ * 1. Corrects font size not being inherited in all browsers
+ * 2. Addresses margins set differently in IE6/7, FF3+, S5, Chrome
+ * 3. Improves appearance and consistency in all browsers
+ */
+
+button,
+input,
+select,
+textarea {
+    font-size: 100%; /* 1 */
+    margin: 0; /* 2 */
+    vertical-align: baseline; /* 3 */
+    *vertical-align: middle; /* 3 */
+}
+
+/*
+ * Addresses FF3/4 setting line-height on 'input' using !important in the UA stylesheet
+ */
+
+button,
+input {
+    line-height: normal; /* 1 */
+}
+
+/*
+ * 1. Improves usability and consistency of cursor style between image-type 'input' and others
+ * 2. Corrects inability to style clickable 'input' types in iOS
+ * 3. Removes inner spacing in IE7 without affecting normal text inputs
+ *    Known issue: inner spacing remains in IE6
+ */
+
+button,
+input[type="button"],
+input[type="reset"],
+input[type="submit"] {
+    cursor: pointer; /* 1 */
+    -webkit-appearance: button; /* 2 */
+    *overflow: visible;  /* 3 */
+}
+
+/*
+ * Re-set default cursor for disabled elements
+ */
+
+button[disabled],
+input[disabled] {
+    cursor: default;
+}
+
+/*
+ * 1. Addresses box sizing set to content-box in IE8/9
+ * 2. Removes excess padding in IE8/9
+ * 3. Removes excess padding in IE7
+      Known issue: excess padding remains in IE6
+ */
+
+input[type="checkbox"],
+input[type="radio"] {
+    box-sizing: border-box; /* 1 */
+    padding: 0; /* 2 */
+    *height: 13px; /* 3 */
+    *width: 13px; /* 3 */
+}
+
+/*
+ * 1. Addresses appearance set to searchfield in S5, Chrome
+ * 2. Addresses box-sizing set to border-box in S5, Chrome (include -moz to future-proof)
+ */
+
+input[type="search"] {
+    -webkit-appearance: textfield; /* 1 */
+    -moz-box-sizing: content-box;
+    -webkit-box-sizing: content-box; /* 2 */
+    box-sizing: content-box;
+}
+
+/*
+ * Removes inner padding and search cancel button in S5, Chrome on OS X
+ */
+
+input[type="search"]::-webkit-search-decoration,
+input[type="search"]::-webkit-search-cancel-button {
+    -webkit-appearance: none;
+}
+
+/*
+ * Removes inner padding and border in FF3+
+ * www.sitepen.com/blog/2008/05/14/the-devils-in-the-details-fixing-dojos-toolbar-buttons/
+ */
+
+button::-moz-focus-inner,
+input::-moz-focus-inner {
+    border: 0;
+    padding: 0;
+}
+
+/*
+ * 1. Removes default vertical scrollbar in IE6/7/8/9
+ * 2. Improves readability and alignment in all browsers
+ */
+
+textarea {
+    overflow: auto; /* 1 */
+    vertical-align: top; /* 2 */
+}
+
+
+/* =============================================================================
+   Tables
+   ========================================================================== */
+
+/*
+ * Remove most spacing between table cells
+ */
+
+table {
+    border-collapse: collapse;
+    border-spacing: 0;
+}

--- a/build/themes/rainier/scss/_normalize.scss
+++ b/build/themes/rainier/scss/_normalize.scss
@@ -1,11 +1,33 @@
-/*! normalize.css 2012-03-11T12:53 UTC - http://github.com/necolas/normalize.css */
+/*! normalize.css v3.0.2 | MIT License | git.io/normalize */
 
-/* =============================================================================
-   HTML5 display definitions
+/**
+ * 1. Set default font family to sans-serif.
+ * 2. Prevent iOS text size adjust after orientation change, without disabling
+ *    user zoom.
+ */
+
+html {
+  font-family: sans-serif; /* 1 */
+  -ms-text-size-adjust: 100%; /* 2 */
+  -webkit-text-size-adjust: 100%; /* 2 */
+}
+
+/**
+ * Remove default margin.
+ */
+
+body {
+  margin: 0;
+}
+
+/* HTML5 display definitions
    ========================================================================== */
 
-/*
- * Corrects block display not defined in IE6/7/8/9 & FF3
+/**
+ * Correct `block` display not defined for any HTML5 element in IE 8/9.
+ * Correct `block` display not defined for `details` or `summary` in IE 10/11
+ * and Firefox.
+ * Correct `block` display not defined for `main` in IE 11.
  */
 
 article,
@@ -16,492 +38,390 @@ figure,
 footer,
 header,
 hgroup,
+main,
+menu,
 nav,
 section,
 summary {
-    display: block;
+  display: block;
 }
 
-/*
- * Corrects inline-block display not defined in IE6/7/8/9 & FF3
+/**
+ * 1. Correct `inline-block` display not defined in IE 8/9.
+ * 2. Normalize vertical alignment of `progress` in Chrome, Firefox, and Opera.
  */
 
 audio,
 canvas,
+progress,
 video {
-    display: inline-block;
-    *display: inline;
-    *zoom: 1;
+  display: inline-block; /* 1 */
+  vertical-align: baseline; /* 2 */
 }
 
-/*
- * Prevents modern browsers from displaying 'audio' without controls
- * Remove excess height in iOS5 devices
+/**
+ * Prevent modern browsers from displaying `audio` without controls.
+ * Remove excess height in iOS 5 devices.
  */
 
 audio:not([controls]) {
-    display: none;
-    height: 0;
+  display: none;
+  height: 0;
 }
 
-/*
- * Addresses styling for 'hidden' attribute not present in IE7/8/9, FF3, S4
- * Known issue: no IE6 support
+/**
+ * Address `[hidden]` styling not present in IE 8/9/10.
+ * Hide the `template` element in IE 8/9/11, Safari, and Firefox < 22.
  */
 
-[hidden] {
-    display: none;
+[hidden],
+template {
+  display: none;
 }
 
-
-/* =============================================================================
-   Base
+/* Links
    ========================================================================== */
 
-/*
- * 1. Corrects text resizing oddly in IE6/7 when body font-size is set using em units
- *    http://clagnut.com/blog/348/#c790
- * 2. Prevents iOS text size adjust after orientation change, without disabling user zoom
- *    www.456bereastreet.com/archive/201012/controlling_text_size_in_safari_for_ios_without_disabling_user_zoom/
+/**
+ * Remove the gray background color from active links in IE 10.
  */
 
-html {
-    font-size: 100%; /* 1 */
-    -webkit-text-size-adjust: 100%; /* 2 */
-    -ms-text-size-adjust: 100%; /* 2 */
+a {
+  background-color: transparent;
 }
 
-/*
- * Addresses font-family inconsistency between 'textarea' and other form elements.
+/**
+ * Improve readability when focused and also mouse hovered in all browsers.
  */
 
-html,
-button,
-input,
-select,
-textarea {
-    font-family: sans-serif;
+a:active,
+a:hover {
+  outline: 0;
 }
 
-/*
- * Addresses margins handled incorrectly in IE6/7
- */
-
-body {
-    margin: 10px;
-    font-family: serif;
-    font-size: 16px;
-    background-color: #ccc;
-}
-
-
-/* =============================================================================
-   Links
+/* Text-level semantics
    ========================================================================== */
 
-/*
- * Addresses outline displayed oddly in Chrome
- */
-
-a:focus {
-    outline: thin dotted;
-}
-
-/*
- * Improves readability when focused and also mouse hovered in all browsers
- * people.opera.com/patrickl/experiments/keyboard/test
- */
-
-a:hover,
-a:active {
-    outline: 0;
-}
-
-
-/* =============================================================================
-   Typography
-   ========================================================================== */
-
-/*
- * Addresses font sizes and margins set differently in IE6/7
- * Addresses font sizes within 'section' and 'article' in FF4+, Chrome, S5
- */
-
-h1 {
-    font-size: 2em;
-    margin: 0.67em 0;
-}
-
-h2 {
-    font-size: 1.5em;
-    margin: 0.83em 0;
-}
-
-h3 {
-    font-size: 1.17em;
-    margin: 1em 0;
-}
-
-h4 {
-    font-size: 1em;
-    margin: 1.33em 0;
-}
-
-h5 {
-    font-size: 0.83em;
-    margin: 1.67em 0;
-}
-
-h6 {
-    font-size: 0.75em;
-    margin: 2.33em 0;
-}
-
-/*
- * Addresses styling not present in IE7/8/9, S5, Chrome
+/**
+ * Address styling not present in IE 8/9/10/11, Safari, and Chrome.
  */
 
 abbr[title] {
-    border-bottom: 1px dotted;
+  border-bottom: 1px dotted;
 }
 
-/*
- * Addresses style set to 'bolder' in FF3+, S4/5, Chrome
-*/
+/**
+ * Address style set to `bolder` in Firefox 4+, Safari, and Chrome.
+ */
 
 b,
 strong {
-    font-weight: bold;
+  font-weight: bold;
 }
 
-blockquote {
-    margin: 1em 40px;
-}
-
-/*
- * Addresses styling not present in S5, Chrome
+/**
+ * Address styling not present in Safari and Chrome.
  */
 
 dfn {
-    font-style: italic;
+  font-style: italic;
 }
 
-/*
- * Addresses styling not present in IE6/7/8/9
+/**
+ * Address variable `h1` font-size and margin within `section` and `article`
+ * contexts in Firefox 4+, Safari, and Chrome.
+ */
+
+h1 {
+  font-size: 2em;
+  margin: 0.67em 0;
+}
+
+/**
+ * Address styling not present in IE 8/9.
  */
 
 mark {
-    background: #ff0;
-    color: #000;
+  background: #ff0;
+  color: #000;
 }
 
-/*
- * Addresses margins set differently in IE6/7
+/**
+ * Address inconsistent and variable font size in all browsers.
  */
-
-p,
-pre {
-    margin: 1em 0;
-}
-
-/*
- * Corrects font family set oddly in IE6, S4/5, Chrome
- * en.wikipedia.org/wiki/User:Davidgothberg/Test59
- */
-
-pre,
-code,
-kbd,
-samp {
-    font-family: monospace, serif;
-    _font-family: 'courier new', monospace;
-    font-size: 1em;
-}
-
-/*
- * Improves readability of pre-formatted text in all browsers
- */
-
-pre {
-    white-space: pre;
-    white-space: pre-wrap;
-    word-wrap: break-word;
-}
-
-/*
- * 1. Addresses CSS quotes not supported in IE6/7
- * 2. Addresses quote property not supported in S4
- */
-
-/* 1 */
-
-q {
-    quotes: none;
-}
-
-/* 2 */
-
-q:before,
-q:after {
-    content: '';
-    content: none;
-}
 
 small {
-    font-size: 75%;
+  font-size: 80%;
 }
 
-/*
- * Prevents sub and sup affecting line-height in all browsers
- * gist.github.com/413930
+/**
+ * Prevent `sub` and `sup` affecting `line-height` in all browsers.
  */
 
 sub,
 sup {
-    font-size: 75%;
-    line-height: 0;
-    position: relative;
-    vertical-align: baseline;
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
 }
 
 sup {
-    top: -0.5em;
+  top: -0.5em;
 }
 
 sub {
-    bottom: -0.25em;
+  bottom: -0.25em;
 }
 
-
-/* =============================================================================
-   Lists
+/* Embedded content
    ========================================================================== */
 
-/*
- * Addresses margins set differently in IE6/7
- */
-
-dl,
-menu,
-ol,
-ul {
-    margin: 1em 0;
-}
-
-dd {
-    margin: 0 0 0 40px;
-}
-
-/*
- * Addresses paddings set differently in IE6/7
- */
-
-menu,
-ol,
-ul {
-    padding: 0 0 0 40px;
-}
-
-/*
- * Corrects list images handled incorrectly in IE7
- */
-
-nav ul,
-nav ol {
-    list-style: none;
-    list-style-image: none;
-}
-
-
-/* =============================================================================
-   Embedded content
-   ========================================================================== */
-
-/*
- * 1. Removes border when inside 'a' element in IE6/7/8/9, FF3
- * 2. Improves image quality when scaled in IE7
- *    code.flickr.com/blog/2008/11/12/on-ui-quality-the-little-things-client-side-image-resizing/
+/**
+ * Remove border when inside `a` element in IE 8/9/10.
  */
 
 img {
-    border: 0; /* 1 */
-    -ms-interpolation-mode: bicubic; /* 2 */
+  border: 0;
 }
 
-/*
- * Corrects overflow displayed oddly in IE9
+/**
+ * Correct overflow not hidden in IE 9/10/11.
  */
 
 svg:not(:root) {
-    overflow: hidden;
+  overflow: hidden;
 }
 
-
-/* =============================================================================
-   Figures
+/* Grouping content
    ========================================================================== */
 
-/*
- * Addresses margin not present in IE6/7/8/9, S5, O11
+/**
+ * Address margin not present in IE 8/9 and Safari.
  */
 
 figure {
-    margin: 0;
+  margin: 1em 40px;
 }
 
+/**
+ * Address differences between Firefox and other browsers.
+ */
 
-/* =============================================================================
-   Forms
+hr {
+  -moz-box-sizing: content-box;
+  box-sizing: content-box;
+  height: 0;
+}
+
+/**
+ * Contain overflow in all browsers.
+ */
+
+pre {
+  overflow: auto;
+}
+
+/**
+ * Address odd `em`-unit font size rendering in all browsers.
+ */
+
+code,
+kbd,
+pre,
+samp {
+  font-family: monospace, monospace;
+  font-size: 1em;
+}
+
+/* Forms
    ========================================================================== */
 
-/*
- * Corrects margin displayed oddly in IE6/7
+/**
+ * Known limitation: by default, Chrome and Safari on OS X allow very limited
+ * styling of `select`, unless a `border` property is set.
  */
 
-form {
-    margin: 0;
-}
-
-/*
- * Define consistent border, margin, and padding
- */
-
-fieldset {
-    border: 1px solid #c0c0c0;
-    margin: 0 2px;
-    padding: 0.35em 0.625em 0.75em;
-}
-
-/*
- * 1. Corrects color not being inherited in IE6/7/8/9
- * 2. Corrects text not wrapping in FF3
- * 3. Corrects alignment displayed oddly in IE6/7
- */
-
-legend {
-    border: 0; /* 1 */
-    padding: 0;
-    white-space: normal; /* 2 */
-    *margin-left: -7px; /* 3 */
-}
-
-/*
- * 1. Corrects font size not being inherited in all browsers
- * 2. Addresses margins set differently in IE6/7, FF3+, S5, Chrome
- * 3. Improves appearance and consistency in all browsers
+/**
+ * 1. Correct color not being inherited.
+ *    Known issue: affects color of disabled elements.
+ * 2. Correct font properties not being inherited.
+ * 3. Address margins set differently in Firefox 4+, Safari, and Chrome.
  */
 
 button,
 input,
+optgroup,
 select,
 textarea {
-    font-size: 100%; /* 1 */
-    margin: 0; /* 2 */
-    vertical-align: baseline; /* 3 */
-    *vertical-align: middle; /* 3 */
+  color: inherit; /* 1 */
+  font: inherit; /* 2 */
+  margin: 0; /* 3 */
 }
 
-/*
- * Addresses FF3/4 setting line-height on 'input' using !important in the UA stylesheet
+/**
+ * Address `overflow` set to `hidden` in IE 8/9/10/11.
+ */
+
+button {
+  overflow: visible;
+}
+
+/**
+ * Address inconsistent `text-transform` inheritance for `button` and `select`.
+ * All other form control elements do not inherit `text-transform` values.
+ * Correct `button` style inheritance in Firefox, IE 8/9/10/11, and Opera.
+ * Correct `select` style inheritance in Firefox.
  */
 
 button,
-input {
-    line-height: normal; /* 1 */
+select {
+  text-transform: none;
 }
 
-/*
- * 1. Improves usability and consistency of cursor style between image-type 'input' and others
- * 2. Corrects inability to style clickable 'input' types in iOS
- * 3. Removes inner spacing in IE7 without affecting normal text inputs
- *    Known issue: inner spacing remains in IE6
+/**
+ * 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio`
+ *    and `video` controls.
+ * 2. Correct inability to style clickable `input` types in iOS.
+ * 3. Improve usability and consistency of cursor style between image-type
+ *    `input` and others.
  */
 
 button,
-input[type="button"],
+html input[type="button"], /* 1 */
 input[type="reset"],
 input[type="submit"] {
-    cursor: pointer; /* 1 */
-    -webkit-appearance: button; /* 2 */
-    *overflow: visible;  /* 3 */
+  -webkit-appearance: button; /* 2 */
+  cursor: pointer; /* 3 */
 }
 
-/*
- * Re-set default cursor for disabled elements
+/**
+ * Re-set default cursor for disabled elements.
  */
 
 button[disabled],
-input[disabled] {
-    cursor: default;
+html input[disabled] {
+  cursor: default;
 }
 
-/*
- * 1. Addresses box sizing set to content-box in IE8/9
- * 2. Removes excess padding in IE8/9
- * 3. Removes excess padding in IE7
-      Known issue: excess padding remains in IE6
- */
-
-input[type="checkbox"],
-input[type="radio"] {
-    box-sizing: border-box; /* 1 */
-    padding: 0; /* 2 */
-    *height: 13px; /* 3 */
-    *width: 13px; /* 3 */
-}
-
-/*
- * 1. Addresses appearance set to searchfield in S5, Chrome
- * 2. Addresses box-sizing set to border-box in S5, Chrome (include -moz to future-proof)
- */
-
-input[type="search"] {
-    -webkit-appearance: textfield; /* 1 */
-    -moz-box-sizing: content-box;
-    -webkit-box-sizing: content-box; /* 2 */
-    box-sizing: content-box;
-}
-
-/*
- * Removes inner padding and search cancel button in S5, Chrome on OS X
- */
-
-input[type="search"]::-webkit-search-decoration,
-input[type="search"]::-webkit-search-cancel-button {
-    -webkit-appearance: none;
-}
-
-/*
- * Removes inner padding and border in FF3+
- * www.sitepen.com/blog/2008/05/14/the-devils-in-the-details-fixing-dojos-toolbar-buttons/
+/**
+ * Remove inner padding and border in Firefox 4+.
  */
 
 button::-moz-focus-inner,
 input::-moz-focus-inner {
-    border: 0;
-    padding: 0;
+  border: 0;
+  padding: 0;
 }
 
-/*
- * 1. Removes default vertical scrollbar in IE6/7/8/9
- * 2. Improves readability and alignment in all browsers
+/**
+ * Address Firefox 4+ setting `line-height` on `input` using `!important` in
+ * the UA stylesheet.
+ */
+
+input {
+  line-height: normal;
+}
+
+/**
+ * It's recommended that you don't attempt to style these elements.
+ * Firefox's implementation doesn't respect box-sizing, padding, or width.
+ *
+ * 1. Address box sizing set to `content-box` in IE 8/9/10.
+ * 2. Remove excess padding in IE 8/9/10.
+ */
+
+input[type="checkbox"],
+input[type="radio"] {
+  box-sizing: border-box; /* 1 */
+  padding: 0; /* 2 */
+}
+
+/**
+ * Fix the cursor style for Chrome's increment/decrement buttons. For certain
+ * `font-size` values of the `input`, it causes the cursor style of the
+ * decrement button to change from `default` to `text`.
+ */
+
+input[type="number"]::-webkit-inner-spin-button,
+input[type="number"]::-webkit-outer-spin-button {
+  height: auto;
+}
+
+/**
+ * 1. Address `appearance` set to `searchfield` in Safari and Chrome.
+ * 2. Address `box-sizing` set to `border-box` in Safari and Chrome
+ *    (include `-moz` to future-proof).
+ */
+
+input[type="search"] {
+  -webkit-appearance: textfield; /* 1 */
+  -moz-box-sizing: content-box;
+  -webkit-box-sizing: content-box; /* 2 */
+  box-sizing: content-box;
+}
+
+/**
+ * Remove inner padding and search cancel button in Safari and Chrome on OS X.
+ * Safari (but not Chrome) clips the cancel button when the search input has
+ * padding (and `textfield` appearance).
+ */
+
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+/**
+ * Define consistent border, margin, and padding.
+ */
+
+fieldset {
+  border: 1px solid #c0c0c0;
+  margin: 0 2px;
+  padding: 0.35em 0.625em 0.75em;
+}
+
+/**
+ * 1. Correct `color` not being inherited in IE 8/9/10/11.
+ * 2. Remove padding so people aren't caught out if they zero out fieldsets.
+ */
+
+legend {
+  border: 0; /* 1 */
+  padding: 0; /* 2 */
+}
+
+/**
+ * Remove default vertical scrollbar in IE 8/9/10/11.
  */
 
 textarea {
-    overflow: auto; /* 1 */
-    vertical-align: top; /* 2 */
+  overflow: auto;
 }
 
+/**
+ * Don't inherit the `font-weight` (applied by a rule above).
+ * NOTE: the default cannot safely be changed in Chrome and Safari on OS X.
+ */
 
-/* =============================================================================
-   Tables
+optgroup {
+  font-weight: bold;
+}
+
+/* Tables
    ========================================================================== */
 
-/*
- * Remove most spacing between table cells
+/**
+ * Remove most spacing between table cells.
  */
 
 table {
-    border-collapse: collapse;
-    border-spacing: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+td,
+th {
+  padding: 0;
 }

--- a/build/themes/rainier/scss/_variable.scss
+++ b/build/themes/rainier/scss/_variable.scss
@@ -1,0 +1,37 @@
+// Font
+$sans-serif: "Helvetica Neue", Helvetica, Arial, sans-serif;
+$monospace: monospace;
+$font-size: 14px;
+
+// Color
+$fg: rgb(43, 43, 43);
+$bg: rgb(255, 255, 255);
+
+$base: rgb(39, 74, 120);
+$darkest: darken($base, 30%);
+$dark: darken($base, 15%);
+$light: lighten($base, 15%);
+$lightest: lighten($base, 30%);
+
+$dark-gray: rgb(123, 124, 125);
+$gray: rgb(192, 198, 201);
+$light-gray: rgb(220, 221, 221);
+
+// Semantics
+$link: $base;
+$link-hover: $light;
+
+// Ratio
+$ratio: 1.618; // Golden Ratio
+
+
+// Margin
+$indent: em($ratio);
+$harf-indent: ($indent / 2);
+$default-margin: $indent 0;
+
+$gap: 1%;
+
+
+// Icon
+$icon-search: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyRpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMy1jMDExIDY2LjE0NTY2MSwgMjAxMi8wMi8wNi0xNDo1NjoyNyAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNiAoTWFjaW50b3NoKSIgeG1wTU06SW5zdGFuY2VJRD0ieG1wLmlpZDozNERDNTZFOUUzODAxMUUxQUQzMjk4ODQyRUU1RDcyQSIgeG1wTU06RG9jdW1lbnRJRD0ieG1wLmRpZDozNERDNTZFQUUzODAxMUUxQUQzMjk4ODQyRUU1RDcyQSI+IDx4bXBNTTpEZXJpdmVkRnJvbSBzdFJlZjppbnN0YW5jZUlEPSJ4bXAuaWlkOjM0REM1NkU3RTM4MDExRTFBRDMyOTg4NDJFRTVENzJBIiBzdFJlZjpkb2N1bWVudElEPSJ4bXAuZGlkOjM0REM1NkU4RTM4MDExRTFBRDMyOTg4NDJFRTVENzJBIi8+IDwvcmRmOkRlc2NyaXB0aW9uPiA8L3JkZjpSREY+IDwveDp4bXBtZXRhPiA8P3hwYWNrZXQgZW5kPSJyIj8+JBJqMQAAAbtJREFUeNq8lTtIA0EQhpMgxhfBTo02CXIYRKxUrCSKYBFT24gIimJrIVgoiNZ2lqaQFGIhFhamURGMUUQQRA3W56NKIWKq81+Zg2HZR0SSgY/sXO72v51/di/oeV6gmhGsmcB5/lr+rwPMgRToBU3ABRdgHxwB7duNDA/+/oZUomAVFMEGEHc20/VOMAUOQYGEjRFSTJ4BW6DF8uwAuARDppvqpHwFzEjXHkAOlEACTNKKRESoVP3g3SbQBdZZXgZLtCJP8mYPjFHeBjbBvK1Es6CB5WLyXYWRryAN7tm1aV1JuUBKKkvGUNovsMbyMFuRViDOxjlTC1KcSHncJhBh41IFe+ib8KPVJuCycaICgZjk2YdNoMDGohXbLQJy11zZBA7YWPR5FjRqJh8Hyyx/Arc2AbH971g+Sm+VZqWI0S4/BvXs3u1KD7tucKMxrEztqApxbiW5j7rD7gVMgDfFJGGDHw44BVHbYeeb3Qd2pDbk8QgW6M2NIqbvQYC2vzC0hwwXK8szr6I0qSOXCyVyVaepHJ9kvi5cqj0XcagDk7oS/TV8kSLLF00e/EfkjNr7ufYf/WrFjwADAK0DbczFhrQCAAAAAElFTkSuQmCC";

--- a/build/themes/rainier/scss/base.scss
+++ b/build/themes/rainier/scss/base.scss
@@ -1,0 +1,12 @@
+@import 'function';
+
+@import 'variable';
+@import 'grid';
+@import 'clearfix';
+@import 'component';
+@import 'layout';
+
+@import 'basics';
+@import 'feedback';
+
+// @import 'debug';

--- a/build/themes/rainier/scss/base.scss
+++ b/build/themes/rainier/scss/base.scss
@@ -9,4 +9,6 @@
 @import 'basics';
 @import 'feedback';
 
+.hidden { display: none; }
+
 // @import 'debug';

--- a/build/themes/rainier/scss/editor.scss
+++ b/build/themes/rainier/scss/editor.scss
@@ -1,0 +1,16 @@
+@import 'function';
+
+@import 'variable';
+@import 'basics';
+
+body {
+  margin: 0 auto;
+//  border-width: 0 1px;
+//  border-style: dotted;
+//  border-color: #f3f3f3;
+//  padding: 0 $gap;
+}
+
+body > p:first-child {
+  margin-top: 0;
+}

--- a/build/themes/rainier/scss/ie.scss
+++ b/build/themes/rainier/scss/ie.scss
@@ -1,0 +1,214 @@
+@import 'function';
+@import 'variable';
+@import 'grid';
+
+// Grid
+.span {
+    float: left;
+}
+.span1 { width: $colspan01 }
+.span2 { width: $colspan02 }
+.span3 { width: $colspan03 }
+.span4 { width: $colspan04 }
+.span5 { width: $colspan05 }
+.span6 { width: $colspan06 }
+.span7 { width: $colspan07 }
+.span8 { width: $colspan08 }
+.span9 { width: $colspan09 }
+.span10 { width: $colspan10 }
+.span11 { width: $colspan11 }
+.span12 { width: $colspan12 }
+// .span13 { width: $colspan13 }
+// .span14 { width: $colspan14 }
+// .span15 { width: $colspan15 }
+// .span16 { width: $colspan16 }
+
+
+// Layout
+#container {
+  #container-inner,
+  #header-inner,
+  #content-inner,
+  #footer-inner {
+    width: 940px;
+    margin-right: auto;
+    margin-left: auto;
+  }
+}
+
+// Pagination
+.pagination {
+  margin: $indent 0;
+
+  ul {
+    display: block;
+  }
+}
+
+
+// Breadcrumb
+.breadcrumb {
+  margin-right: $gap;
+  margin-left: $gap;
+
+  li {
+    display: inline-block;
+  }
+}
+
+
+// Header
+[role="banner"] {
+  margin: 0 auto;
+
+  #header-content {
+    margin: $indent $gap;
+  }
+
+  h1 {
+    margin: 0;
+  }
+
+  [role="navigation"] {
+    width: 100%;
+    padding: 0;
+
+    ul {
+      display: block;
+      margin: 0 $gap;
+
+      li {
+        float: left;
+        padding: 0;
+      }
+    }
+
+    a {
+      display: block;
+      padding: 0 1em 0 0;
+      text-decoration: none;
+    }
+
+    select {
+      display: none;
+    }
+  }
+}
+
+// Content
+#content {
+  margin-right: auto;
+  margin-left: auto;
+
+  [role="main"],
+  .related {
+    float: left;
+  }
+
+  [role="main"] {
+    width: 640px;
+    padding-left: 15px;
+  }
+
+  .related {
+    width: 235px;
+    padding-left: 50px;
+    margin-top: 0;
+  }
+}
+
+// Widget
+.widget {
+  margin-right: 15px;
+}
+
+// Entries List
+#posts {
+  div,
+  time {
+    float: left;
+    margin-left: $gap;
+    margin-right: $gap;
+  }
+
+  div {
+    width: 73.0%;
+  }
+
+  time {
+    width: 23.0%;
+  }
+}
+
+
+// Entry Summary
+.entry-summary {
+  figure {
+    display: inline-block;
+    float: right;
+
+    img {
+      margin: $harf-indent 0 0 $harf-indent;
+    }
+  }
+}
+
+// Footer
+[role="contentinfo"] {
+  [role="navigation"],
+  .license,
+  .poweredby {
+    margin: $harf-indent 0;
+    padding-right: $gap;
+    padding-left: $gap;
+  }
+
+  [role="navigation"],
+  .license {
+    float: left;
+  }
+
+  [role="navigation"] {
+    width: $colspan08;
+
+    li {
+      display: inline-block;;
+    }
+  }
+
+  .license {
+    width: $colspan04;
+    text-align: right;
+  }
+}
+
+// Search
+#search {
+  div {
+    display: block;
+  }
+
+  input[type="text"] {
+    width: 100%;
+    height: auto;
+    padding: 0.5em ($indent * 1.5) 0.5em 0.5em;
+  }
+}
+
+
+// Feedback
+#comments-open-data {
+  input[type="text"] {
+    width: 75%;
+  }
+}
+
+#comments-open-footer {
+  text-align: left;
+
+  input[type="submit"],
+  input[type="button"] {
+    width: auto;
+    margin-right: $harf-indent;
+  }
+}

--- a/build/themes/rainier/scss/rainier-white/screen.scss
+++ b/build/themes/rainier/scss/rainier-white/screen.scss
@@ -1,0 +1,17 @@
+/*
+
+name: Rainier (White)
+designer: Six Apart, Ltd.
+designer_url: http://www.sixapart.com/
+layouts: layout-wt
+
+*/
+
+@import '../function';
+
+@import '../variable';
+@import '../grid';
+@import '../component';
+@import '../decoration';
+
+// @import '../debug';

--- a/themes/rainier/static/css/base.css
+++ b/themes/rainier/static/css/base.css
@@ -121,12 +121,33 @@ button,
     [role="contentinfo"] {
       margin: 0 auto; } }
 
-/* normalize.css 2012-03-11T12:53 UTC - http://github.com/necolas/normalize.css */
-/* =============================================================================
-   HTML5 display definitions
+/*! normalize.css v3.0.2 | MIT License | git.io/normalize */
+/**
+ * 1. Set default font family to sans-serif.
+ * 2. Prevent iOS text size adjust after orientation change, without disabling
+ *    user zoom.
+ */
+html {
+  font-family: sans-serif;
+  /* 1 */
+  -ms-text-size-adjust: 100%;
+  /* 2 */
+  -webkit-text-size-adjust: 100%;
+  /* 2 */ }
+
+/**
+ * Remove default margin.
+ */
+body {
+  margin: 0; }
+
+/* HTML5 display definitions
    ========================================================================== */
-/*
- * Corrects block display not defined in IE6/7/8/9 & FF3
+/**
+ * Correct `block` display not defined for any HTML5 element in IE 8/9.
+ * Correct `block` display not defined for `details` or `summary` in IE 10/11
+ * and Firefox.
+ * Correct `block` display not defined for `main` in IE 11.
  */
 article,
 aside,
@@ -136,196 +157,101 @@ figure,
 footer,
 header,
 hgroup,
+main,
+menu,
 nav,
 section,
 summary {
   display: block; }
 
-/*
- * Corrects inline-block display not defined in IE6/7/8/9 & FF3
+/**
+ * 1. Correct `inline-block` display not defined in IE 8/9.
+ * 2. Normalize vertical alignment of `progress` in Chrome, Firefox, and Opera.
  */
 audio,
 canvas,
+progress,
 video {
   display: inline-block;
-  *display: inline;
-  *zoom: 1; }
+  /* 1 */
+  vertical-align: baseline;
+  /* 2 */ }
 
-/*
- * Prevents modern browsers from displaying 'audio' without controls
- * Remove excess height in iOS5 devices
+/**
+ * Prevent modern browsers from displaying `audio` without controls.
+ * Remove excess height in iOS 5 devices.
  */
 audio:not([controls]) {
   display: none;
   height: 0; }
 
-/*
- * Addresses styling for 'hidden' attribute not present in IE7/8/9, FF3, S4
- * Known issue: no IE6 support
+/**
+ * Address `[hidden]` styling not present in IE 8/9/10.
+ * Hide the `template` element in IE 8/9/11, Safari, and Firefox < 22.
  */
-[hidden] {
+[hidden],
+template {
   display: none; }
 
-/* =============================================================================
-   Base
+/* Links
    ========================================================================== */
-/*
- * 1. Corrects text resizing oddly in IE6/7 when body font-size is set using em units
- *    http://clagnut.com/blog/348/#c790
- * 2. Prevents iOS text size adjust after orientation change, without disabling user zoom
- *    www.456bereastreet.com/archive/201012/controlling_text_size_in_safari_for_ios_without_disabling_user_zoom/
+/**
+ * Remove the gray background color from active links in IE 10.
  */
-html {
-  font-size: 100%;
-  /* 1 */
-  -webkit-text-size-adjust: 100%;
-  /* 2 */
-  -ms-text-size-adjust: 100%;
-  /* 2 */ }
+a {
+  background-color: transparent; }
 
-/*
- * Addresses font-family inconsistency between 'textarea' and other form elements.
+/**
+ * Improve readability when focused and also mouse hovered in all browsers.
  */
-html,
-button,
-input,
-select,
-textarea {
-  font-family: sans-serif; }
-
-/*
- * Addresses margins handled incorrectly in IE6/7
- */
-body {
-  margin: 10px;
-  font-family: serif;
-  font-size: 16px;
-  background-color: #ccc; }
-
-/* =============================================================================
-   Links
-   ========================================================================== */
-/*
- * Addresses outline displayed oddly in Chrome
- */
-a:focus {
-  outline: thin dotted; }
-
-/*
- * Improves readability when focused and also mouse hovered in all browsers
- * people.opera.com/patrickl/experiments/keyboard/test
- */
-a:hover,
-a:active {
+a:active,
+a:hover {
   outline: 0; }
 
-/* =============================================================================
-   Typography
+/* Text-level semantics
    ========================================================================== */
-/*
- * Addresses font sizes and margins set differently in IE6/7
- * Addresses font sizes within 'section' and 'article' in FF4+, Chrome, S5
+/**
+ * Address styling not present in IE 8/9/10/11, Safari, and Chrome.
+ */
+abbr[title] {
+  border-bottom: 1px dotted; }
+
+/**
+ * Address style set to `bolder` in Firefox 4+, Safari, and Chrome.
+ */
+b,
+strong {
+  font-weight: bold; }
+
+/**
+ * Address styling not present in Safari and Chrome.
+ */
+dfn {
+  font-style: italic; }
+
+/**
+ * Address variable `h1` font-size and margin within `section` and `article`
+ * contexts in Firefox 4+, Safari, and Chrome.
  */
 h1 {
   font-size: 2em;
   margin: 0.67em 0; }
 
-h2 {
-  font-size: 1.5em;
-  margin: 0.83em 0; }
-
-h3 {
-  font-size: 1.17em;
-  margin: 1em 0; }
-
-h4 {
-  font-size: 1em;
-  margin: 1.33em 0; }
-
-h5 {
-  font-size: 0.83em;
-  margin: 1.67em 0; }
-
-h6 {
-  font-size: 0.75em;
-  margin: 2.33em 0; }
-
-/*
- * Addresses styling not present in IE7/8/9, S5, Chrome
- */
-abbr[title] {
-  border-bottom: 1px dotted; }
-
-/*
- * Addresses style set to 'bolder' in FF3+, S4/5, Chrome
-*/
-b,
-strong {
-  font-weight: bold; }
-
-blockquote {
-  margin: 1em 40px; }
-
-/*
- * Addresses styling not present in S5, Chrome
- */
-dfn {
-  font-style: italic; }
-
-/*
- * Addresses styling not present in IE6/7/8/9
+/**
+ * Address styling not present in IE 8/9.
  */
 mark {
   background: #ff0;
   color: #000; }
 
-/*
- * Addresses margins set differently in IE6/7
+/**
+ * Address inconsistent and variable font size in all browsers.
  */
-p,
-pre {
-  margin: 1em 0; }
-
-/*
- * Corrects font family set oddly in IE6, S4/5, Chrome
- * en.wikipedia.org/wiki/User:Davidgothberg/Test59
- */
-pre,
-code,
-kbd,
-samp {
-  font-family: monospace, serif;
-  _font-family: 'courier new', monospace;
-  font-size: 1em; }
-
-/*
- * Improves readability of pre-formatted text in all browsers
- */
-pre {
-  white-space: pre;
-  white-space: pre-wrap;
-  word-wrap: break-word; }
-
-/*
- * 1. Addresses CSS quotes not supported in IE6/7
- * 2. Addresses quote property not supported in S4
- */
-/* 1 */
-q {
-  quotes: none; }
-
-/* 2 */
-q:before,
-q:after {
-  content: '';
-  content: none; }
-
 small {
-  font-size: 75%; }
+  font-size: 80%; }
 
-/*
- * Prevents sub and sup affecting line-height in all browsers
- * gist.github.com/413930
+/**
+ * Prevent `sub` and `sup` affecting `line-height` in all browsers.
  */
 sub,
 sup {
@@ -340,167 +266,157 @@ sup {
 sub {
   bottom: -0.25em; }
 
-/* =============================================================================
-   Lists
+/* Embedded content
    ========================================================================== */
-/*
- * Addresses margins set differently in IE6/7
- */
-dl,
-menu,
-ol,
-ul {
-  margin: 1em 0; }
-
-dd {
-  margin: 0 0 0 40px; }
-
-/*
- * Addresses paddings set differently in IE6/7
- */
-menu,
-ol,
-ul {
-  padding: 0 0 0 40px; }
-
-/*
- * Corrects list images handled incorrectly in IE7
- */
-nav ul,
-nav ol {
-  list-style: none;
-  list-style-image: none; }
-
-/* =============================================================================
-   Embedded content
-   ========================================================================== */
-/*
- * 1. Removes border when inside 'a' element in IE6/7/8/9, FF3
- * 2. Improves image quality when scaled in IE7
- *    code.flickr.com/blog/2008/11/12/on-ui-quality-the-little-things-client-side-image-resizing/
+/**
+ * Remove border when inside `a` element in IE 8/9/10.
  */
 img {
-  border: 0;
-  /* 1 */
-  -ms-interpolation-mode: bicubic;
-  /* 2 */ }
+  border: 0; }
 
-/*
- * Corrects overflow displayed oddly in IE9
+/**
+ * Correct overflow not hidden in IE 9/10/11.
  */
 svg:not(:root) {
   overflow: hidden; }
 
-/* =============================================================================
-   Figures
+/* Grouping content
    ========================================================================== */
-/*
- * Addresses margin not present in IE6/7/8/9, S5, O11
+/**
+ * Address margin not present in IE 8/9 and Safari.
  */
 figure {
-  margin: 0; }
+  margin: 1em 40px; }
 
-/* =============================================================================
-   Forms
+/**
+ * Address differences between Firefox and other browsers.
+ */
+hr {
+  -moz-box-sizing: content-box;
+  box-sizing: content-box;
+  height: 0; }
+
+/**
+ * Contain overflow in all browsers.
+ */
+pre {
+  overflow: auto; }
+
+/**
+ * Address odd `em`-unit font size rendering in all browsers.
+ */
+code,
+kbd,
+pre,
+samp {
+  font-family: monospace, monospace;
+  font-size: 1em; }
+
+/* Forms
    ========================================================================== */
-/*
- * Corrects margin displayed oddly in IE6/7
+/**
+ * Known limitation: by default, Chrome and Safari on OS X allow very limited
+ * styling of `select`, unless a `border` property is set.
  */
-form {
-  margin: 0; }
-
-/*
- * Define consistent border, margin, and padding
- */
-fieldset {
-  border: 1px solid #c0c0c0;
-  margin: 0 2px;
-  padding: 0.35em 0.625em 0.75em; }
-
-/*
- * 1. Corrects color not being inherited in IE6/7/8/9
- * 2. Corrects text not wrapping in FF3
- * 3. Corrects alignment displayed oddly in IE6/7
- */
-legend {
-  border: 0;
-  /* 1 */
-  padding: 0;
-  white-space: normal;
-  /* 2 */
-  *margin-left: -7px;
-  /* 3 */ }
-
-/*
- * 1. Corrects font size not being inherited in all browsers
- * 2. Addresses margins set differently in IE6/7, FF3+, S5, Chrome
- * 3. Improves appearance and consistency in all browsers
+/**
+ * 1. Correct color not being inherited.
+ *    Known issue: affects color of disabled elements.
+ * 2. Correct font properties not being inherited.
+ * 3. Address margins set differently in Firefox 4+, Safari, and Chrome.
  */
 button,
 input,
+optgroup,
 select,
 textarea {
-  font-size: 100%;
+  color: inherit;
   /* 1 */
-  margin: 0;
+  font: inherit;
   /* 2 */
-  vertical-align: baseline;
-  /* 3 */
-  *vertical-align: middle;
+  margin: 0;
   /* 3 */ }
 
-/*
- * Addresses FF3/4 setting line-height on 'input' using !important in the UA stylesheet
+/**
+ * Address `overflow` set to `hidden` in IE 8/9/10/11.
  */
-button,
-input {
-  line-height: normal;
-  /* 1 */ }
+button {
+  overflow: visible; }
 
-/*
- * 1. Improves usability and consistency of cursor style between image-type 'input' and others
- * 2. Corrects inability to style clickable 'input' types in iOS
- * 3. Removes inner spacing in IE7 without affecting normal text inputs
- *    Known issue: inner spacing remains in IE6
+/**
+ * Address inconsistent `text-transform` inheritance for `button` and `select`.
+ * All other form control elements do not inherit `text-transform` values.
+ * Correct `button` style inheritance in Firefox, IE 8/9/10/11, and Opera.
+ * Correct `select` style inheritance in Firefox.
  */
 button,
-input[type="button"],
+select {
+  text-transform: none; }
+
+/**
+ * 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio`
+ *    and `video` controls.
+ * 2. Correct inability to style clickable `input` types in iOS.
+ * 3. Improve usability and consistency of cursor style between image-type
+ *    `input` and others.
+ */
+button,
+html input[type="button"],
 input[type="reset"],
 input[type="submit"] {
-  cursor: pointer;
-  /* 1 */
   -webkit-appearance: button;
   /* 2 */
-  *overflow: visible;
+  cursor: pointer;
   /* 3 */ }
 
-/*
- * Re-set default cursor for disabled elements
+/**
+ * Re-set default cursor for disabled elements.
  */
 button[disabled],
-input[disabled] {
+html input[disabled] {
   cursor: default; }
 
-/*
- * 1. Addresses box sizing set to content-box in IE8/9
- * 2. Removes excess padding in IE8/9
- * 3. Removes excess padding in IE7
-      Known issue: excess padding remains in IE6
+/**
+ * Remove inner padding and border in Firefox 4+.
+ */
+button::-moz-focus-inner,
+input::-moz-focus-inner {
+  border: 0;
+  padding: 0; }
+
+/**
+ * Address Firefox 4+ setting `line-height` on `input` using `!important` in
+ * the UA stylesheet.
+ */
+input {
+  line-height: normal; }
+
+/**
+ * It's recommended that you don't attempt to style these elements.
+ * Firefox's implementation doesn't respect box-sizing, padding, or width.
+ *
+ * 1. Address box sizing set to `content-box` in IE 8/9/10.
+ * 2. Remove excess padding in IE 8/9/10.
  */
 input[type="checkbox"],
 input[type="radio"] {
   box-sizing: border-box;
   /* 1 */
   padding: 0;
-  /* 2 */
-  *height: 13px;
-  /* 3 */
-  *width: 13px;
-  /* 3 */ }
+  /* 2 */ }
 
-/*
- * 1. Addresses appearance set to searchfield in S5, Chrome
- * 2. Addresses box-sizing set to border-box in S5, Chrome (include -moz to future-proof)
+/**
+ * Fix the cursor style for Chrome's increment/decrement buttons. For certain
+ * `font-size` values of the `input`, it causes the cursor style of the
+ * decrement button to change from `default` to `text`.
+ */
+input[type="number"]::-webkit-inner-spin-button,
+input[type="number"]::-webkit-outer-spin-button {
+  height: auto; }
+
+/**
+ * 1. Address `appearance` set to `searchfield` in Safari and Chrome.
+ * 2. Address `box-sizing` set to `border-box` in Safari and Chrome
+ *    (include `-moz` to future-proof).
  */
 input[type="search"] {
   -webkit-appearance: textfield;
@@ -510,41 +426,58 @@ input[type="search"] {
   /* 2 */
   box-sizing: content-box; }
 
-/*
- * Removes inner padding and search cancel button in S5, Chrome on OS X
+/**
+ * Remove inner padding and search cancel button in Safari and Chrome on OS X.
+ * Safari (but not Chrome) clips the cancel button when the search input has
+ * padding (and `textfield` appearance).
  */
-input[type="search"]::-webkit-search-decoration,
-input[type="search"]::-webkit-search-cancel-button {
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-decoration {
   -webkit-appearance: none; }
 
-/*
- * Removes inner padding and border in FF3+
- * www.sitepen.com/blog/2008/05/14/the-devils-in-the-details-fixing-dojos-toolbar-buttons/
+/**
+ * Define consistent border, margin, and padding.
  */
-button::-moz-focus-inner,
-input::-moz-focus-inner {
-  border: 0;
-  padding: 0; }
+fieldset {
+  border: 1px solid #c0c0c0;
+  margin: 0 2px;
+  padding: 0.35em 0.625em 0.75em; }
 
-/*
- * 1. Removes default vertical scrollbar in IE6/7/8/9
- * 2. Improves readability and alignment in all browsers
+/**
+ * 1. Correct `color` not being inherited in IE 8/9/10/11.
+ * 2. Remove padding so people aren't caught out if they zero out fieldsets.
  */
-textarea {
-  overflow: auto;
+legend {
+  border: 0;
   /* 1 */
-  vertical-align: top;
+  padding: 0;
   /* 2 */ }
 
-/* =============================================================================
-   Tables
+/**
+ * Remove default vertical scrollbar in IE 8/9/10/11.
+ */
+textarea {
+  overflow: auto; }
+
+/**
+ * Don't inherit the `font-weight` (applied by a rule above).
+ * NOTE: the default cannot safely be changed in Chrome and Safari on OS X.
+ */
+optgroup {
+  font-weight: bold; }
+
+/* Tables
    ========================================================================== */
-/*
- * Remove most spacing between table cells
+/**
+ * Remove most spacing between table cells.
  */
 table {
   border-collapse: collapse;
   border-spacing: 0; }
+
+td,
+th {
+  padding: 0; }
 
 input,
 select,
@@ -1032,4 +965,5 @@ button,
   .trackback p {
     margin: 0.809em 0 0; }
 
-.hidden { display: none; }
+.hidden {
+  display: none; }


### PR DESCRIPTION
The "normalize.css" in the rainier is too old.
Some definitions sometimes make warnings in browser console.
The "normalize.css" is updated to v3.0.2 by this branch.

Please verify rendered HTML and marge this branch.

Thanks!

P.S, I hope that "build/themes/rainier" is removed from the movabletype repository.
https://github.com/movabletype/movabletype/tree/master/build/themes/rainier