### PR TITLE
Convert movabletype/mt-theme-rainier to GitHub Actions MTC-29590

### DIFF
--- a/.github/workflows/mt-theme-rainier.yml
+++ b/.github/workflows/mt-theme-rainier.yml
@@ -16,4 +16,4 @@ jobs:
     - name: checkout
       uses: actions/checkout@v4.1.0
     - run: npm install -g sass
-    - run: file=$(find . -name "[^_]*.scss" -type f); echo -e "$file"; echo $file | xargs -n1 sass --check
+    - run: find . -name "[^_]*.scss" -type f | xargs -I {} sh -c 'echo {}; sass --silence-deprecation=global-builtin,slash-div,import,color-functions {} /dev/null'

--- a/.github/workflows/mt-theme-rainier.yml
+++ b/.github/workflows/mt-theme-rainier.yml
@@ -1,0 +1,17 @@
+name: movabletype/mt-theme-rainier
+on:
+  push:
+    branches:
+    - "**/*"
+  pull_request:
+concurrency:
+#   # This item has no matching transformer
+#   maximum_number_of_builds: 0
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4.1.0
+    - run: gem install sass
+    - run: file=$(find . -name "[^_]*.scss" -type f); echo -e "$file"; echo $file | xargs -n1 sass --check

--- a/.github/workflows/mt-theme-rainier.yml
+++ b/.github/workflows/mt-theme-rainier.yml
@@ -16,4 +16,4 @@ jobs:
     - name: checkout
       uses: actions/checkout@v4.1.0
     - run: npm install -g sass
-    - run: find . -name "[^_]*.scss" -type f | xargs -I {} sh -c 'echo {}; sass --silence-deprecation=global-builtin,slash-div,import,color-functions {} /dev/null'
+    - run: find . -name "[^_]*.scss" -type f | xargs -I {} sh -c 'echo {}; sass --silence-deprecation=global-builtin,slash-div,import,color-functions {} tmp/output.css'

--- a/.github/workflows/mt-theme-rainier.yml
+++ b/.github/workflows/mt-theme-rainier.yml
@@ -15,5 +15,5 @@ jobs:
     steps:
     - name: checkout
       uses: actions/checkout@v4.1.0
-    - run: gem install sass
+    - run: npm install -g sass
     - run: file=$(find . -name "[^_]*.scss" -type f); echo -e "$file"; echo $file | xargs -n1 sass --check

--- a/.github/workflows/mt-theme-rainier.yml
+++ b/.github/workflows/mt-theme-rainier.yml
@@ -7,6 +7,8 @@ on:
 concurrency:
 #   # This item has no matching transformer
 #   maximum_number_of_builds: 0
+  group: "${{ github.ref }}"
+  cancel-in-progress: true
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: ruby
-
-install: gem install sass
-
-script: file=$(find . -name "[^_]*.scss" -type f); echo -e "$file"; echo $file | xargs -n1 sass --check
-


### PR DESCRIPTION
Pipeline migrated from [Travis CI](https://travis-ci.com/movabletype/mt-theme-rainier) :tada:

Especially by this commit https://github.com/movabletype/mt-theme-rainier/pull/12/commits/be67c0afeeb707434a67f199a3854765d7154a9c,  we use dart-sass instead of Ruby sass to check sass files. The following deprecation warnings are suppressed by the `--silince-deprecation` option.
- global-builtin
```
Deprecation Warning [global-builtin]: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
```
- slash-div
```
Deprecation Warning [slash-div]: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.
```
- import
```
Deprecation Warning [import]: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
```
- color-functions
```
Deprecation Warning [color-functions]: darken() is deprecated.
Deprecation Warning [color-functions]: lighten() is deprecated.
```